### PR TITLE
Implement Query Locks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 
+## [Unreleased]
+
+### Changed
+- Implement query locks to prevent duplicate data in multithreaded environments (from @justjasongreen)
+
+
 ## [1.0.0a2] - 2016-07-23
 
 ### Added
@@ -41,6 +47,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Set up project (from @justjasongreen)
 
 
+[Unreleased]: https://github.com/justjasongreen/racing_data/compare/1.0.0a2...HEAD
 [1.0.0a2]: https://github.com/justjasongreen/racing_data/compare/1.0.0a1...1.0.0a2
 [1.0.0a1]: https://github.com/justjasongreen/racing_data/compare/1.0.0a0...1.0.0a1
 [1.0.0a0]: https://github.com/justjasongreen/racing_data/tree/1.0.0a0


### PR DESCRIPTION
Wrap the Provider.find_or_create and find_or_create_one methods in contextual locks to prevent duplicate data in multithreaded environments.

(closes #27)
